### PR TITLE
Identify posts in post lists that have children

### DIFF
--- a/default.css
+++ b/default.css
@@ -40,6 +40,10 @@ img {
     vertical-align: middle;
 }
 
+img[data-has_children="true"] {
+	box-shadow: 5px 10px #888;
+}
+
 input {
     padding: 0 0.5em;
 }

--- a/includes/post_list.php
+++ b/includes/post_list.php
@@ -132,6 +132,7 @@ require "includes/header.php";?>
                             $result = $db->query($query) or die($db->error);
                             //Limit main tag listing to 40 tags. Keep the loop down to the minimum really.
                             while ($row = $result->fetch_assoc()) {
+								$post = new post();
                                 $tags = mb_trim($row['tags']);
                                 if ($tcount <= 40) {
                                     $ttags = explode(" ", $tags);
@@ -148,6 +149,7 @@ require "includes/header.php";?>
                                         <a id="p:id" href=":href">
                                             <img src=":imgSrc" 
                                                  alt="post" 
+                                                 data-has_children=":hasChildren"
                                                  title=":title"/>
                                         </a>', [
                                     ':id' => $row['id'],
@@ -157,6 +159,7 @@ require "includes/header.php";?>
                                             'id' => $row['id'],
                                         ]),
                                     ':imgSrc' => $thumbnailManager->makeIfNeeded($row['directory'] . '/' . $row['image']),
+                                    ':hasChildren' => $post->has_children($row['id']),
                                     ':title' => $row['tags'] . ' score:' . $row['score'] . ' rating:' . $row['rating'],
                                 ]);
 


### PR DESCRIPTION
Use the built-in `post->has_children(id)` method while rendering post list to tag posts with custom `data-has_children='true'` attribute so that the stylesheet highlights them (with a drop shadow in this example).